### PR TITLE
Add App Store purchase restriction methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,21 +113,23 @@ Note: You'll need to install expo-build-properties if you haven't already:
 
 ## App Store purchase restrictions
 
-You can restrict App Store purchases through the following methods:
+These methods mirror Apple's [`ManagedSettings.AppStoreSettings`](https://developer.apple.com/documentation/managedsettings/appstoresettings) `appStore` properties, and each takes a boolean matching the corresponding property:
 
 ```typescript
-// in-app purchases
-await ScreenTime.denyInAppPurchases();  // block in-app purchases
-await ScreenTime.allowInAppPurchases(); // allow in-app purchases
+// in-app purchases (AppStoreSettings.denyInAppPurchases)
+await ScreenTime.denyInAppPurchases(true);  // block in-app purchases
+await ScreenTime.denyInAppPurchases(false); // allow in-app purchases
 
-// require a password for purchases (pass a boolean)
+// require a password for purchases (AppStoreSettings.requirePasswordForPurchases)
 await ScreenTime.requirePasswordForPurchases(true);
 await ScreenTime.requirePasswordForPurchases(false);
 ```
 
-On iOS these write to the corresponding [`ManagedSettings`](https://developer.apple.com/documentation/managedsettings/appstoresettings) `appStore` properties (`denyInAppPurchases` and `requirePasswordForPurchases`), and the current values can be read back from [`getStore()`](#sample-code) under `appStore`.
+On iOS the current values can be read back from [`getStore()`](#sample-code) under `appStore`.
 
-> **⚠️ These restrictions are only enforced on iOS.** Android exposes no system-level API to restrict in-app purchases or require a password for purchases for a regular app, so on Android these methods only persist the flag state to mirror the API — they do not actually enforce any restriction.
+> **`allowInAppPurchases()` is deprecated.** Apple's `AppStoreSettings` has no `allowInAppPurchases` property, so use `denyInAppPurchases(false)` instead. `allowInAppPurchases()` is kept only for backwards compatibility.
+
+> **⚠️ Not supported on Android.** Android exposes no system-level API to block in-app purchases or require a password for purchases for a regular app. These methods exist on Android only to mirror the API surface — they persist the flag state but do **not** enforce any restriction.
 
 ## Sample code
 ```typescript

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Access the Screen Time API for iOS and Wellbeing API for Android (coming soon). 
   - [Add FamilyControls capability to your app](#add-familycontrols-capability-to-your-app)
   - [Request Family Controls capabilities](#request-family-controls-capabilities)
 - [Set up for Expo](#set-up-for-expo)
+- [App Store purchase restrictions](#app-store-purchase-restrictions)
 - [Sample code](#sample-code)
 - [Contributing](#contributing)
 - [Contributors](#contributors)
@@ -109,6 +110,24 @@ entitlements: {
 Note: You'll need to install expo-build-properties if you haven't already:
 
 `expo install expo-build-properties`
+
+## App Store purchase restrictions
+
+You can restrict App Store purchases through the following methods:
+
+```typescript
+// in-app purchases
+await ScreenTime.denyInAppPurchases();  // block in-app purchases
+await ScreenTime.allowInAppPurchases(); // allow in-app purchases
+
+// require a password for purchases (pass a boolean)
+await ScreenTime.requirePasswordForPurchases(true);
+await ScreenTime.requirePasswordForPurchases(false);
+```
+
+On iOS these write to the corresponding [`ManagedSettings`](https://developer.apple.com/documentation/managedsettings/appstoresettings) `appStore` properties (`denyInAppPurchases` and `requirePasswordForPurchases`), and the current values can be read back from [`getStore()`](#sample-code) under `appStore`.
+
+> **⚠️ These restrictions are only enforced on iOS.** Android exposes no system-level API to restrict in-app purchases or require a password for purchases for a regular app, so on Android these methods only persist the flag state to mirror the API — they do not actually enforce any restriction.
 
 ## Sample code
 ```typescript

--- a/android/src/main/java/com/noodleofdeath/screentimeapi/ScreenTimeAPIModule.java
+++ b/android/src/main/java/com/noodleofdeath/screentimeapi/ScreenTimeAPIModule.java
@@ -68,20 +68,32 @@ public class ScreenTimeAPIModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void denyAppRemoval(Promise promise) {
+    public void denyAppRemoval(boolean deny, Promise promise) {
         promise.resolve("success");
     }
 
+    /**
+     * @deprecated Apple's {@code ApplicationSettings} has no {@code allowAppRemoval}
+     *     property; use {@link #denyAppRemoval(boolean, Promise) denyAppRemoval(false)}
+     *     instead. Kept for backwards compatibility.
+     */
+    @Deprecated
     @ReactMethod
     public void allowAppRemoval(Promise promise) {
         promise.resolve("success");
     }
 
     @ReactMethod
-    public void denyAppInstallation(Promise promise) {
+    public void denyAppInstallation(boolean deny, Promise promise) {
         promise.resolve("success");
     }
 
+    /**
+     * @deprecated Apple's {@code ApplicationSettings} has no {@code allowAppInstallation}
+     *     property; use {@link #denyAppInstallation(boolean, Promise) denyAppInstallation(false)}
+     *     instead. Kept for backwards compatibility.
+     */
+    @Deprecated
     @ReactMethod
     public void allowAppInstallation(Promise promise) {
         promise.resolve("success");

--- a/android/src/main/java/com/noodleofdeath/screentimeapi/ScreenTimeAPIModule.java
+++ b/android/src/main/java/com/noodleofdeath/screentimeapi/ScreenTimeAPIModule.java
@@ -1,6 +1,8 @@
 package com.noodleofdeath.screentimeapi;
 
 import android.app.Activity;
+import android.content.Context;
+import android.content.SharedPreferences;
 
 import androidx.annotation.NonNull;
 
@@ -16,8 +18,17 @@ public class ScreenTimeAPIModule extends ReactContextBaseJavaModule {
 
     private static final int REQUEST_CODE_ENABLE_ADMIN = 1;
 
+    private static final String PREFS_NAME = "ScreenTimeAPIPrefs";
+    private static final String KEY_DENY_IN_APP_PURCHASES = "denyInAppPurchases";
+    private static final String KEY_REQUIRE_PASSWORD_FOR_PURCHASES = "requirePasswordForPurchases";
+
     public ScreenTimeAPIModule(ReactApplicationContext reactContext) {
         super(reactContext);
+    }
+
+    private SharedPreferences getPrefs() {
+        return getReactApplicationContext()
+            .getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
     }
 
     @NonNull
@@ -73,6 +84,28 @@ public class ScreenTimeAPIModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void allowAppInstallation(Promise promise) {
+        promise.resolve("success");
+    }
+
+    // Android exposes no system-level in-app purchase restriction for a
+    // regular app, so the flags are only persisted here to mirror the iOS
+    // API; they are not enforced by the OS.
+
+    @ReactMethod
+    public void denyInAppPurchases(Promise promise) {
+        getPrefs().edit().putBoolean(KEY_DENY_IN_APP_PURCHASES, true).apply();
+        promise.resolve("success");
+    }
+
+    @ReactMethod
+    public void allowInAppPurchases(Promise promise) {
+        getPrefs().edit().putBoolean(KEY_DENY_IN_APP_PURCHASES, false).apply();
+        promise.resolve("success");
+    }
+
+    @ReactMethod
+    public void requirePasswordForPurchases(boolean req, Promise promise) {
+        getPrefs().edit().putBoolean(KEY_REQUIRE_PASSWORD_FOR_PURCHASES, req).apply();
         promise.resolve("success");
     }
 

--- a/android/src/main/java/com/noodleofdeath/screentimeapi/ScreenTimeAPIModule.java
+++ b/android/src/main/java/com/noodleofdeath/screentimeapi/ScreenTimeAPIModule.java
@@ -87,22 +87,40 @@ public class ScreenTimeAPIModule extends ReactContextBaseJavaModule {
         promise.resolve("success");
     }
 
-    // Android exposes no system-level in-app purchase restriction for a
-    // regular app, so the flags are only persisted here to mirror the iOS
-    // API; they are not enforced by the OS.
+    // App Store purchase restrictions are not supported on Android: the OS
+    // exposes no system-level API to block in-app purchases or require a
+    // password for purchases for a regular app. The flags are only persisted
+    // here to mirror the iOS API; they are NOT enforced by the OS.
 
+    /**
+     * Not supported on Android. In-app purchase blocking has no Android
+     * equivalent; the flag is persisted but never enforced by the OS.
+     */
     @ReactMethod
-    public void denyInAppPurchases(Promise promise) {
-        getPrefs().edit().putBoolean(KEY_DENY_IN_APP_PURCHASES, true).apply();
+    public void denyInAppPurchases(boolean deny, Promise promise) {
+        getPrefs().edit().putBoolean(KEY_DENY_IN_APP_PURCHASES, deny).apply();
         promise.resolve("success");
     }
 
+    /**
+     * Not supported on Android. In-app purchase blocking has no Android
+     * equivalent; the flag is persisted but never enforced by the OS.
+     *
+     * @deprecated Apple's {@code AppStoreSettings} has no {@code allowInAppPurchases}
+     *     property; use {@link #denyInAppPurchases(boolean, Promise) denyInAppPurchases(false)}
+     *     instead. Kept for backwards compatibility.
+     */
+    @Deprecated
     @ReactMethod
     public void allowInAppPurchases(Promise promise) {
         getPrefs().edit().putBoolean(KEY_DENY_IN_APP_PURCHASES, false).apply();
         promise.resolve("success");
     }
 
+    /**
+     * Not supported on Android. Requiring a password for purchases has no
+     * Android equivalent; the flag is persisted but never enforced by the OS.
+     */
     @ReactMethod
     public void requirePasswordForPurchases(boolean req, Promise promise) {
         getPrefs().edit().putBoolean(KEY_REQUIRE_PASSWORD_FOR_PURCHASES, req).apply();

--- a/index.d.ts
+++ b/index.d.ts
@@ -277,13 +277,25 @@ export type IScreenTimeAPI = {
   clearBlockedApplications: () => Promise<void>;
 
   /**
+   * Sets whether app installation is denied.
+   *
+   * Mirrors Apple's
+   * [`ApplicationSettings.denyAppInstallation`](https://developer.apple.com/documentation/managedsettings/applicationsettings/denyappinstallation).
+   * On iOS this sets `ManagedSettingsStore.application.denyAppInstallation`; the
+   * current value is readable via {@link getStore} (`application.denyAppInstallation`).
    * @platform ios
    * @platform android
+   * @param {boolean} deny whether app installation is denied
    * @returns {Promise<void>}
    */
-  denyAppInstallation: () => Promise<void>;
+  denyAppInstallation: (deny: boolean) => Promise<void>;
 
   /**
+   * Allows app installation.
+   *
+   * @deprecated Apple's `ApplicationSettings` has no `allowAppInstallation`
+   * property; use {@link denyAppInstallation}`(false)` instead. Kept for
+   * backwards compatibility.
    * @platform ios
    * @platform android
    * @returns {Promise<void>}
@@ -291,13 +303,25 @@ export type IScreenTimeAPI = {
   allowAppInstallation: () => Promise<void>;
 
   /**
+   * Sets whether app removal is denied.
+   *
+   * Mirrors Apple's
+   * [`ApplicationSettings.denyAppRemoval`](https://developer.apple.com/documentation/managedsettings/applicationsettings/denyappremoval).
+   * On iOS this sets `ManagedSettingsStore.application.denyAppRemoval`; the
+   * current value is readable via {@link getStore} (`application.denyAppRemoval`).
    * @platform ios
    * @platform android
+   * @param {boolean} deny whether app removal is denied
    * @returns {Promise<void>}
    */
-  denyAppRemoval: () => Promise<void>;
+  denyAppRemoval: (deny: boolean) => Promise<void>;
 
   /**
+   * Allows app removal.
+   *
+   * @deprecated Apple's `ApplicationSettings` has no `allowAppRemoval`
+   * property; use {@link denyAppRemoval}`(false)` instead. Kept for
+   * backwards compatibility.
    * @platform ios
    * @platform android
    * @returns {Promise<void>}

--- a/index.d.ts
+++ b/index.d.ts
@@ -303,7 +303,44 @@ export type IScreenTimeAPI = {
    * @returns {Promise<void>}
    */
   allowAppRemoval: () => Promise<void>;
-  
+
+  /**
+   * Denies in-app purchases.
+   *
+   * On iOS this sets `ManagedSettingsStore.appStore.denyInAppPurchases = true`;
+   * the current value is readable via {@link getStore} (`appStore.denyInAppPurchases`).
+   * On Android the flag is persisted by this library (Android exposes no
+   * system-level in-app purchase restriction for a regular app).
+   * @platform ios
+   * @platform android
+   * @returns {Promise<void>}
+   */
+  denyInAppPurchases: () => Promise<void>;
+
+  /**
+   * Allows in-app purchases.
+   *
+   * On iOS this sets `ManagedSettingsStore.appStore.denyInAppPurchases = false`.
+   * On Android the flag is persisted by this library.
+   * @platform ios
+   * @platform android
+   * @returns {Promise<void>}
+   */
+  allowInAppPurchases: () => Promise<void>;
+
+  /**
+   * Sets whether a password is required for purchases.
+   *
+   * On iOS this sets `ManagedSettingsStore.appStore.requirePasswordForPurchases`;
+   * the current value is readable via {@link getStore} (`appStore.requirePasswordForPurchases`).
+   * On Android the flag is persisted by this library.
+   * @platform ios
+   * @platform android
+   * @param {boolean} req whether a password is required for purchases
+   * @returns {Promise<void>}
+   */
+  requirePasswordForPurchases: (req: boolean) => Promise<void>;
+
   /**
    * @platform ios
    * @returns {Promise<string>}

--- a/index.d.ts
+++ b/index.d.ts
@@ -305,25 +305,31 @@ export type IScreenTimeAPI = {
   allowAppRemoval: () => Promise<void>;
 
   /**
-   * Denies in-app purchases.
+   * Sets whether in-app purchases are denied.
    *
-   * On iOS this sets `ManagedSettingsStore.appStore.denyInAppPurchases = true`;
-   * the current value is readable via {@link getStore} (`appStore.denyInAppPurchases`).
-   * On Android the flag is persisted by this library (Android exposes no
-   * system-level in-app purchase restriction for a regular app).
+   * Mirrors Apple's
+   * [`AppStoreSettings.denyInAppPurchases`](https://developer.apple.com/documentation/managedsettings/appstoresettings/denyinapppurchases).
+   * On iOS this sets `ManagedSettingsStore.appStore.denyInAppPurchases`; the
+   * current value is readable via {@link getStore} (`appStore.denyInAppPurchases`).
+   *
+   * Not supported on Android — Android exposes no system-level API to block
+   * in-app purchases for a regular app, so this call has no effect there.
    * @platform ios
-   * @platform android
+   * @param {boolean} deny whether in-app purchases are denied
    * @returns {Promise<void>}
    */
-  denyInAppPurchases: () => Promise<void>;
+  denyInAppPurchases: (deny: boolean) => Promise<void>;
 
   /**
    * Allows in-app purchases.
    *
-   * On iOS this sets `ManagedSettingsStore.appStore.denyInAppPurchases = false`.
-   * On Android the flag is persisted by this library.
+   * @deprecated Apple's `AppStoreSettings` has no `allowInAppPurchases`
+   * property; use {@link denyInAppPurchases}`(false)` instead. Kept for
+   * backwards compatibility.
+   *
+   * Not supported on Android — Android exposes no system-level API to block
+   * in-app purchases for a regular app, so this call has no effect there.
    * @platform ios
-   * @platform android
    * @returns {Promise<void>}
    */
   allowInAppPurchases: () => Promise<void>;
@@ -331,11 +337,14 @@ export type IScreenTimeAPI = {
   /**
    * Sets whether a password is required for purchases.
    *
+   * Mirrors Apple's
+   * [`AppStoreSettings.requirePasswordForPurchases`](https://developer.apple.com/documentation/managedsettings/appstoresettings/requirepasswordforpurchases).
    * On iOS this sets `ManagedSettingsStore.appStore.requirePasswordForPurchases`;
    * the current value is readable via {@link getStore} (`appStore.requirePasswordForPurchases`).
-   * On Android the flag is persisted by this library.
+   *
+   * Not supported on Android — Android exposes no system-level API to require
+   * a password for purchases for a regular app, so this call has no effect there.
    * @platform ios
-   * @platform android
    * @param {boolean} req whether a password is required for purchases
    * @returns {Promise<void>}
    */

--- a/ios/ReactNativeScreenTimeAPI/ReactNativeScreenTimeAPI.m
+++ b/ios/ReactNativeScreenTimeAPI/ReactNativeScreenTimeAPI.m
@@ -32,6 +32,9 @@ RCT_EXTERN_METHOD(denyAppRemoval)
 RCT_EXTERN_METHOD(allowAppRemoval)
 RCT_EXTERN_METHOD(denyAppInstallation)
 RCT_EXTERN_METHOD(allowAppInstallation)
+RCT_EXTERN_METHOD(denyInAppPurchases)
+RCT_EXTERN_METHOD(allowInAppPurchases)
+RCT_EXTERN_METHOD(requirePasswordForPurchases: (BOOL) req)
 RCT_EXTERN_METHOD(displayFamilyActivityPicker: (NSDictionary *) options
                   resolver: (RCTPromiseResolveBlock) resolve
                   rejecter: (RCTPromiseRejectBlock) reject)

--- a/ios/ReactNativeScreenTimeAPI/ReactNativeScreenTimeAPI.m
+++ b/ios/ReactNativeScreenTimeAPI/ReactNativeScreenTimeAPI.m
@@ -32,7 +32,7 @@ RCT_EXTERN_METHOD(denyAppRemoval)
 RCT_EXTERN_METHOD(allowAppRemoval)
 RCT_EXTERN_METHOD(denyAppInstallation)
 RCT_EXTERN_METHOD(allowAppInstallation)
-RCT_EXTERN_METHOD(denyInAppPurchases)
+RCT_EXTERN_METHOD(denyInAppPurchases: (BOOL) deny)
 RCT_EXTERN_METHOD(allowInAppPurchases)
 RCT_EXTERN_METHOD(requirePasswordForPurchases: (BOOL) req)
 RCT_EXTERN_METHOD(displayFamilyActivityPicker: (NSDictionary *) options

--- a/ios/ReactNativeScreenTimeAPI/ReactNativeScreenTimeAPI.m
+++ b/ios/ReactNativeScreenTimeAPI/ReactNativeScreenTimeAPI.m
@@ -28,9 +28,9 @@ RCT_EXTERN_METHOD(setActivitySelection: (NSDictionary *) selection
                   resolver: (RCTPromiseResolveBlock) resolve
                   rejecter: (RCTPromiseRejectBlock) reject)
 RCT_EXTERN_METHOD(clearActivitySelection)
-RCT_EXTERN_METHOD(denyAppRemoval)
+RCT_EXTERN_METHOD(denyAppRemoval: (BOOL) deny)
 RCT_EXTERN_METHOD(allowAppRemoval)
-RCT_EXTERN_METHOD(denyAppInstallation)
+RCT_EXTERN_METHOD(denyAppInstallation: (BOOL) deny)
 RCT_EXTERN_METHOD(allowAppInstallation)
 RCT_EXTERN_METHOD(denyInAppPurchases: (BOOL) deny)
 RCT_EXTERN_METHOD(allowInAppPurchases)

--- a/ios/ReactNativeScreenTimeAPI/ReactNativeScreenTimeAPI.swift
+++ b/ios/ReactNativeScreenTimeAPI/ReactNativeScreenTimeAPI.swift
@@ -232,10 +232,12 @@ public class ScreenTimeAPI: NSObject {
   }
 
   @objc
-  public func denyInAppPurchases() {
-    store.appStore.denyInAppPurchases = true
+  public func denyInAppPurchases(_ deny: Bool) {
+    store.appStore.denyInAppPurchases = deny
   }
 
+  /// Deprecated: `AppStoreSettings` has no `allowInAppPurchases` property.
+  /// Use `denyInAppPurchases(false)` instead. Kept for backwards compatibility.
   @objc
   public func allowInAppPurchases() {
     store.appStore.denyInAppPurchases = false

--- a/ios/ReactNativeScreenTimeAPI/ReactNativeScreenTimeAPI.swift
+++ b/ios/ReactNativeScreenTimeAPI/ReactNativeScreenTimeAPI.swift
@@ -230,7 +230,22 @@ public class ScreenTimeAPI: NSObject {
   public func allowAppInstallation() {
     store.application.denyAppInstallation = false
   }
-  
+
+  @objc
+  public func denyInAppPurchases() {
+    store.appStore.denyInAppPurchases = true
+  }
+
+  @objc
+  public func allowInAppPurchases() {
+    store.appStore.denyInAppPurchases = false
+  }
+
+  @objc
+  public func requirePasswordForPurchases(_ req: Bool) {
+    store.appStore.requirePasswordForPurchases = req
+  }
+
   @objc
   public func initializeMonitoring(_ startTimestamp: String = "00:00",
                                    end endTimestamp: String = "23:59",

--- a/ios/ReactNativeScreenTimeAPI/ReactNativeScreenTimeAPI.swift
+++ b/ios/ReactNativeScreenTimeAPI/ReactNativeScreenTimeAPI.swift
@@ -212,20 +212,24 @@ public class ScreenTimeAPI: NSObject {
   }
   
   @objc
-  public func denyAppRemoval() {
-    store.application.denyAppRemoval = true
+  public func denyAppRemoval(_ deny: Bool) {
+    store.application.denyAppRemoval = deny
   }
-  
+
+  /// Deprecated: `ApplicationSettings` has no `allowAppRemoval` property.
+  /// Use `denyAppRemoval(false)` instead. Kept for backwards compatibility.
   @objc
   public func allowAppRemoval() {
     store.application.denyAppRemoval = false
   }
-  
+
   @objc
-  public func denyAppInstallation() {
-    store.application.denyAppInstallation = true
+  public func denyAppInstallation(_ deny: Bool) {
+    store.application.denyAppInstallation = deny
   }
-  
+
+  /// Deprecated: `ApplicationSettings` has no `allowAppInstallation` property.
+  /// Use `denyAppInstallation(false)` instead. Kept for backwards compatibility.
   @objc
   public func allowAppInstallation() {
     store.application.denyAppInstallation = false


### PR DESCRIPTION
Expose deny/allow controls for in-app purchases and a setter for requiring a password for purchases, mapping to the iOS ManagedSettings appStore properties (denyInAppPurchases, requirePasswordForPurchases). The current values remain readable via getStore().

- iOS: write store.appStore.denyInAppPurchases / requirePasswordForPurchases
- Android: persist flag state via SharedPreferences (no OS-level enforcement available for a regular app)
- Document the new methods and note iOS-only enforcement in the README